### PR TITLE
Support UART over MMC

### DIFF
--- a/Conf/Sun5i/A13.dsc.inc
+++ b/Conf/Sun5i/A13.dsc.inc
@@ -1,12 +1,19 @@
 [PcdsFixedAtBuild]
+!if $(UART_ON_MMC) != TRUE
+  # UART0 is multiplexed with MMC, if we use UART, we can't use MMC.
   gSunxiTokenSpaceGuid.Mmc0Base     | 0x01c0f000
+!endif
   # MMC1 seems unused on all A13 boards.
   # gSunxiTokenSpaceGuid.Mmc1Base     | 0x01c10000
   # FIXME: eMMC support is broken
   #gSunxiTokenSpaceGuid.Mmc2Base     | 0x01c11000
 
   gSunxiTokenSpaceGuid.CcmBase      | 0x01c20000
+!if $(UART_ON_MMC) == TRUE
+  gSunxiTokenSpaceGuid.UartBase     | 0x01c28000
+!else
   gSunxiTokenSpaceGuid.UartBase     | 0x01c28400
+!endif
   gSunxiTokenSpaceGuid.PcdGpioBase  | 0x01c20800
   gSunxiTokenSpaceGuid.TimerBase    | 0x01c20c00
   gSunxiTokenSpaceGuid.WatchdogBase | 0x01c20c90


### PR DESCRIPTION
Allwinner A13 boards have UART multiplexed on uSD socket. This allows to
access UART without disassembling device.